### PR TITLE
Mc task component edits

### DIFF
--- a/kanbantooelectricboogaloo.client/src/components/ListComponent.vue
+++ b/kanbantooelectricboogaloo.client/src/components/ListComponent.vue
@@ -28,8 +28,6 @@ import { AppState } from '../AppState'
 import { computed, onMounted, reactive } from 'vue'
 import { boardService } from '../services/BoardService'
 import { TaskComponent } from '../components/TaskComponent'
-// import { useRoute } from 'vue-router'
-
 export default {
   name: 'ListComponent',
   props: {

--- a/kanbantooelectricboogaloo.client/src/main.js
+++ b/kanbantooelectricboogaloo.client/src/main.js
@@ -3,10 +3,14 @@ import App from './App.vue'
 import { createApp } from 'vue'
 import { registerGlobalComponents } from './registerGlobalComponents'
 import router from './router'
+import bootstrap from 'bootstrap'
+import jquery from 'jquery'
+import popper from 'popper.js'
+import corejs from 'core-js'
 
 const root = createApp(App)
 registerGlobalComponents(root)
 
 root
-  .use(router)
+  .use(router, bootstrap, jquery, popper, corejs)
   .mount('#app')

--- a/kanbantooelectricboogaloo.client/src/main.js
+++ b/kanbantooelectricboogaloo.client/src/main.js
@@ -4,7 +4,7 @@ import { createApp } from 'vue'
 import { registerGlobalComponents } from './registerGlobalComponents'
 import router from './router'
 import bootstrap from 'bootstrap'
-import jquery from 'jquery'
+// import jquery from 'jquery'
 import popper from 'popper.js'
 import corejs from 'core-js'
 
@@ -12,5 +12,5 @@ const root = createApp(App)
 registerGlobalComponents(root)
 
 root
-  .use(router, bootstrap, jquery, popper, corejs)
+  .use(router, bootstrap, popper, corejs)
   .mount('#app')

--- a/kanbantooelectricboogaloo.client/src/pages/ActiveBoardPage.vue
+++ b/kanbantooelectricboogaloo.client/src/pages/ActiveBoardPage.vue
@@ -92,6 +92,7 @@ export default {
         boardService.createList(state.newList)
         state.newList.body = ''
         $('#listModal').modal('toggle')
+        $('.modal-backdrop').remove()
       }
     }
   }

--- a/kanbantooelectricboogaloo.client/src/pages/ActiveBoardPage.vue
+++ b/kanbantooelectricboogaloo.client/src/pages/ActiveBoardPage.vue
@@ -63,7 +63,7 @@ import { AppState } from '../AppState'
 import { boardService } from '../services/BoardService'
 import { useRoute } from 'vue-router'
 import ListComponent from '../components/ListComponent'
-
+import $ from 'jquery'
 export default {
   name: 'ActiveBoardPage',
   components: { ListComponent },
@@ -89,8 +89,9 @@ export default {
       lists: computed(() => AppState.activeBoardLists),
       comments: computed(() => AppState.comments),
       createList() {
-        // state.newList.boardId = route.params.boardId
         boardService.createList(state.newList)
+        state.newList.body = ''
+        $('#listModal').modal('hide')
       }
     }
   }

--- a/kanbantooelectricboogaloo.client/src/pages/ActiveBoardPage.vue
+++ b/kanbantooelectricboogaloo.client/src/pages/ActiveBoardPage.vue
@@ -91,7 +91,7 @@ export default {
       createList() {
         boardService.createList(state.newList)
         state.newList.body = ''
-        $('#listModal').modal('hide')
+        $('#listModal').modal('toggle')
       }
     }
   }

--- a/kanbantooelectricboogaloo.client/src/pages/ProfilePage.vue
+++ b/kanbantooelectricboogaloo.client/src/pages/ProfilePage.vue
@@ -90,7 +90,7 @@ export default {
       boards: computed(() => AppState.boards),
       createBoard() {
         boardService.createBoard(state.newBoard)
-        state.newBoard.content = ''
+        state.newBoard.title = ''
         $('#boardModal').modal('toggle')
         $('.modal-backdrop').remove()
       },

--- a/kanbantooelectricboogaloo.client/src/pages/ProfilePage.vue
+++ b/kanbantooelectricboogaloo.client/src/pages/ProfilePage.vue
@@ -92,6 +92,7 @@ export default {
         boardService.createBoard(state.newBoard)
         state.newBoard.content = ''
         $('#boardModal').modal('toggle')
+        $('.modal-backdrop').remove()
       },
       showActiveBoard(id) {
         boardService.showActiveBoard(id)

--- a/kanbantooelectricboogaloo.client/src/pages/ProfilePage.vue
+++ b/kanbantooelectricboogaloo.client/src/pages/ProfilePage.vue
@@ -90,6 +90,7 @@ export default {
       boards: computed(() => AppState.boards),
       createBoard() {
         boardService.createBoard(state.newBoard)
+        state.newBoard.content = ''
         $('#boardModal').modal('toggle')
       },
       showActiveBoard(id) {

--- a/kanbantooelectricboogaloo.client/src/pages/ProfilePage.vue
+++ b/kanbantooelectricboogaloo.client/src/pages/ProfilePage.vue
@@ -45,10 +45,10 @@
                 <div class="col">
                   <div class="modal-footer">
                     <button type="button" class="btn border-0" data-dismiss="modal">
-                      Close
+                      Close    <i class="fas fa-window-close fa-lg ml-2"></i>
                     </button>
                     <button type="submit" class="btn border-0">
-                      Create Board
+                      Create Board <i class="fas fa-clipboard-list fa-lg ml-2"></i>
                     </button>
                   </div>
                 </div>

--- a/kanbantooelectricboogaloo.client/src/pages/ProfilePage.vue
+++ b/kanbantooelectricboogaloo.client/src/pages/ProfilePage.vue
@@ -71,6 +71,7 @@ import { boardService } from '../services/BoardService'
 import BoardComponent from '../components/BoardComponent'
 import router from '../router'
 import { profileService } from '../services/ProfileService'
+import $ from 'jquery'
 
 export default {
   name: 'Profile',
@@ -89,11 +90,10 @@ export default {
       boards: computed(() => AppState.boards),
       createBoard() {
         boardService.createBoard(state.newBoard)
-        console.log(state.newBoard.title)
+        $('#boardModal').modal('toggle')
       },
       showActiveBoard(id) {
         boardService.showActiveBoard(id)
-        // console.log('trying to show board')
         router.push({ name: 'ActiveBoardPage', params: { boardId: id } })
       }
     }


### PR DESCRIPTION
Added some better functionality for nested modals. 

Modals add both a transition and regular backdrop when being launched. Vue 3 struggles to utilize compatibility for these with Bootstrap 4. With that, jQuery must be pulled in to get the full functionality out of the existing modals. Cors-js is also an option and can be utilized like jQuery for modal toggling. Additional testing should be done regarding the difference between the 2 options. 

Note that moving forward, vue-neat-modals could be a better option for modals that can be full customizable, but will require more testing in another project before applying to a fully launched application. 